### PR TITLE
\attribute -> \Attribute

### DIFF
--- a/doc/latex/pgf-umlcd/demo/abstract-class.tex
+++ b/doc/latex/pgf-umlcd/demo/abstract-class.tex
@@ -1,7 +1,7 @@
 \begin{tikzpicture}
   \begin{abstractclass}[text width=5cm]{BankAccount}{0,0}
-    \attribute{owner : String}
-    \attribute{balance : Dollars = 0}
+    \Attribute{owner : String}
+    \Attribute{balance : Dollars = 0}
 
     \operation{deposit(amount : Dollars)}
     \operation[0]{withdrawl(amount : Dollars)}

--- a/doc/latex/pgf-umlcd/demo/association.tex
+++ b/doc/latex/pgf-umlcd/demo/association.tex
@@ -1,20 +1,20 @@
 \begin{tikzpicture}
   \begin{class}[text width=7cm]{Flight}{0,0}
-    \attribute{flightNumber : Integer}
-    \attribute{departureTime : Date}
-    \attribute{flightDuration : Minutes}
-    \attribute{departingAirport : String}
-    \attribute{arrivingAirport : String}
+    \Attribute{flightNumber : Integer}
+    \Attribute{departureTime : Date}
+    \Attribute{flightDuration : Minutes}
+    \Attribute{departingAirport : String}
+    \Attribute{arrivingAirport : String}
 
     \operation{delayFlight ( numberOfMinutes : Minutes )}
     \operation{getArrivalTime ( ) : Date}
   \end{class}
 
   \begin{class}{Plane}{11,0}
-    \attribute{airPlaneType : String}
-    \attribute{maximumSpeed : MPH}
-    \attribute{maximumDistance : Miles}
-    \attribute{tailID : String}
+    \Attribute{airPlaneType : String}
+    \Attribute{maximumSpeed : MPH}
+    \Attribute{maximumDistance : Miles}
+    \Attribute{tailID : String}
   \end{class}
 
   \association{Plane}{assignedPlane}{0..1}{Flight}{0..*}{assignedFlights}

--- a/doc/latex/pgf-umlcd/demo/class.tex
+++ b/doc/latex/pgf-umlcd/demo/class.tex
@@ -1,7 +1,7 @@
 \begin{tikzpicture}
   \begin{class}[text width=8cm]{ClassName}{0,0}
-    \attribute{name : attribute type}
-    \attribute{name : attribute type = default value}
+    \Attribute{name : attribute type}
+    \Attribute{name : attribute type = default value}
 
     \operation{name(parameter list) : type of value returned}
     % virtual operation

--- a/doc/latex/pgf-umlcd/demo/color.tex
+++ b/doc/latex/pgf-umlcd/demo/color.tex
@@ -4,8 +4,8 @@
 
 \begin{tikzpicture}
   \begin{class}[text width=8cm]{ClassName}{0,0}
-    \attribute{name : attribute type}
-    \attribute{name : attribute type = default value}
+    \Attribute{name : attribute type}
+    \Attribute{name : attribute type = default value}
 
     \operation{name(parameter list) : type of value returned}
     % virtual operation

--- a/doc/latex/pgf-umlcd/demo/implement-interface.tex
+++ b/doc/latex/pgf-umlcd/demo/implement-interface.tex
@@ -1,16 +1,16 @@
 \begin{tikzpicture}%[show background grid]
   \begin{interface}{Person}{0,0}
-    \attribute{firstName : String}
-    \attribute{lastName : String}
+    \Attribute{firstName : String}
+    \Attribute{lastName : String}
   \end{interface}
 
   \begin{class}{Professor}{-5,-5}
     \implement{Person}
-    \attribute{salary : Dollars}
+    \Attribute{salary : Dollars}
   \end{class}
 
   \begin{class}{Student}{5,-5}
     \implement{Person}
-    \attribute{major : String}
+    \Attribute{major : String}
   \end{class}
 \end{tikzpicture}

--- a/doc/latex/pgf-umlcd/demo/inheritance.tex
+++ b/doc/latex/pgf-umlcd/demo/inheritance.tex
@@ -1,7 +1,7 @@
 \begin{tikzpicture}
   \begin{class}[text width=5cm]{BankAccount}{0,0}
-    \attribute{owner : String}
-    \attribute{balance : Dollars = 0}
+    \Attribute{owner : String}
+    \Attribute{balance : Dollars = 0}
 
     \operation{deposit(amount : Dollars)}
     \operation[0]{withdrawl(amount : Dollars)}
@@ -9,7 +9,7 @@
 
   \begin{class}[text width=7cm]{CheckingAccount}{-5,-5}
     \inherit{BankAccount}
-    \attribute{insufficientFundsFee : Dollars}
+    \Attribute{insufficientFundsFee : Dollars}
 
     \operation{processCheck ( checkToProcess : Check )}
     \operation{withdrawal ( amount : Dollars )}
@@ -17,7 +17,7 @@
 
   \begin{class}[text width=7cm]{SavingsAccount}{5,-5}
     \inherit{BankAccount}
-    \attribute{annualInteresRate : Percentage}
+    \Attribute{annualInteresRate : Percentage}
 
     \operation{depositMonthlyInterest ( )}
     \operation{withdrawal ( amount : Dollars )}

--- a/doc/latex/pgf-umlcd/demo/interface.tex
+++ b/doc/latex/pgf-umlcd/demo/interface.tex
@@ -1,6 +1,6 @@
 \begin{tikzpicture}%[show background grid]
   \begin{interface}{Person}{0,0}
-    \attribute{firstName : String}
-    \attribute{lastName : String}
+    \Attribute{firstName : String}
+    \Attribute{lastName : String}
   \end{interface}
 \end{tikzpicture}

--- a/doc/latex/pgf-umlcd/demo/object-include-methods.tex
+++ b/doc/latex/pgf-umlcd/demo/object-include-methods.tex
@@ -1,8 +1,8 @@
 \begin{tikzpicture}
   \begin{object}[text width=6cm]{Thomas' account}{0,0}
     \instanceOf{BankAccount}
-    \attribute{owner = Thomas}
-    \attribute{balance = 100}
+    \Attribute{owner = Thomas}
+    \Attribute{balance = 100}
 
     \operation{deposit(amount : Dollars)}
     \operation[0]{withdrawl(amount : Dollars)}

--- a/doc/latex/pgf-umlcd/demo/object.tex
+++ b/doc/latex/pgf-umlcd/demo/object.tex
@@ -1,6 +1,6 @@
 \begin{tikzpicture}
   \begin{object}[text width=6cm]{Instance Name}{0,0}
     \instanceOf{Class Name}
-    \attribute{attribute name = value}
+    \Attribute{attribute name = value}
   \end{object}
 \end{tikzpicture}

--- a/doc/latex/pgf-umlcd/demo/package.tex
+++ b/doc/latex/pgf-umlcd/demo/package.tex
@@ -1,8 +1,8 @@
 \begin{tikzpicture}
   \begin{package}{Accounts}
     \begin{class}[text width=5cm]{BankAccount}{0,0}
-      \attribute{owner : String}
-      \attribute{balance : Dollars = 0}
+      \Attribute{owner : String}
+      \Attribute{balance : Dollars = 0}
 
       \operation{deposit(amount : Dollars)}
       \operation[0]{withdrawl(amount : Dollars)}
@@ -10,7 +10,7 @@
 
     \begin{class}[text width=7cm]{CheckingAccount}{-5,-5}
       \inherit{BankAccount}
-      \attribute{insufficientFundsFee : Dollars}
+      \Attribute{insufficientFundsFee : Dollars}
 
       \operation{processCheck ( checkToProcess : Check )}
       \operation{withdrawal ( amount : Dollars )}
@@ -18,7 +18,7 @@
 
     \begin{class}[text width=7cm]{SavingsAccount}{5,-5}
       \inherit{BankAccount}
-      \attribute{annualInteresRate : Percentage}
+      \Attribute{annualInteresRate : Percentage}
 
       \operation{depositMonthlyInterest ( )}
       \operation{withdrawal ( amount : Dollars )}

--- a/doc/latex/pgf-umlcd/demo/unidirectional-association.tex
+++ b/doc/latex/pgf-umlcd/demo/unidirectional-association.tex
@@ -2,14 +2,14 @@
   % \draw[help lines] (-7,-6) grid (6,0);
 
   \begin{class}[text width=6cm]{OverdrawnAccountsReport}{0,0}
-    \attribute{generatedOn : Date}
+    \Attribute{generatedOn : Date}
 
     \operation{refresh ( )}
   \end{class}
 
   \begin{class}{BankAccount}{12,0}
-    \attribute{owner : String}
-    \attribute{balance : Dollars}
+    \Attribute{owner : String}
+    \Attribute{balance : Dollars}
 
     \operation{deposit(amount : Dollars)}
     \operation[0]{withdrawl(amount : Dollars)}

--- a/doc/latex/pgf-umlcd/demo/visibility.tex
+++ b/doc/latex/pgf-umlcd/demo/visibility.tex
@@ -1,14 +1,14 @@
 \begin{tikzpicture}%[show background grid]
     \begin{class}[text width=7cm]{Class}{0,0}
-    \attribute{+ Public}
-    \attribute{\# Protected}
-    \attribute{- Private}
-    \attribute{$\sim$ Package}
+    \Attribute{+ Public}
+    \Attribute{\# Protected}
+    \Attribute{- Private}
+    \Attribute{$\sim$ Package}
   \end{class}
 
   \begin{class}[text width=7cm]{BankAccount}{0,-3}
-    \attribute{+ owner : String}
-    \attribute{+ balance : Dollars}
+    \Attribute{+ owner : String}
+    \Attribute{+ balance : Dollars}
     
     \operation{+ deposit( amount : Dollars )}
     \operation{+ withdrawal( amount : Dollars )}

--- a/tex/latex/pgf-umlcd/pgf-umlcd.sty
+++ b/tex/latex/pgf-umlcd/pgf-umlcd.sty
@@ -224,7 +224,7 @@ minimum height=1cm, node distance=2cm]
 \protected@xdef\umlcdPackageFit{\umlcdPackageFitOld (\umlcdClassName)}
 }
 
-\newcommand{\attribute}[1]{%
+\newcommand{\Attribute}[1]{%
 \ifnum\c@umlcdClassAttributesNum=0
 \protected@xdef\umlcdClassAttributes{#1}
 \else
@@ -359,6 +359,11 @@ minimum height=1cm, node distance=2cm]
 \newcommand{\umlnote}[1][]{
 	\node[umlcd style, anchor=north, draw,shape=umlcdnote, text width=4cm, #1]
 }
+
+% Backwards compatibility for pdflatex/xelatex
+\expandafter\ifx\csname attribute\endcsname\relax
+	\let\attribute\Attribute
+\fi
 
 %%% End of pgf-umlcd.sty
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
I thought about this a lot, discussed this a lot. First idea was to rename it internally to `\attrib` but this is already used in the memoir class. Therefore I only switched to Uppercase first letter. I am aware that this is not convenient over all macros but I simply don't have any other idea about this.

I added a fallback for the compilers to be backwards compatible but changed all demo files as well. 
Hopefully this can be used to resolve #2.